### PR TITLE
Allow removing products when updating an open sale

### DIFF
--- a/src/pages/Cashier/components/CashierForm.js
+++ b/src/pages/Cashier/components/CashierForm.js
@@ -200,7 +200,7 @@ const CashierForm = ({buttonAction, saleToUpdate, productsToUpdate}) => {
                                 <div className="col-3">
                                     {"$" + new Intl.NumberFormat('es-CL').format(product.total)}
                                 </div>
-                                {!saleToUpdate && <div className="col-1">
+                                {<div className="col-1">
                                     <button type="button" className="btn btn-table btn-sm" onClick={()=>removeProduct(index)} disabled={!isRemoveButtonDisabled()}> <i className="fa-solid fa-xmark"></i></button>
                                 </div>}
                             </div>


### PR DESCRIPTION
## Summary

Allows the cashier to remove products with the X button when updating an open order (Pedidos Abiertos).

## Why

The remove button was conditionally rendered only when creating a new sale (`{!saleToUpdate && ...}`). No backend change is needed — `updateSale` already replaces `saleProducts` and recalculates totals.

## Test

- Open a sale from Pedidos Abiertos and verify the X button appears and removes a product (disabled when only one product remains).